### PR TITLE
avenmia/FixLocalStorageBug

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,6 +44,11 @@ export default Login;
 const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
+  const handleSignOut = async () => {
+    localStorage.polisUserXID = undefined;
+    await signOut();
+  };
+
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <p className="text-center text-2xl text-white">
@@ -53,7 +58,7 @@ const AuthShowcase: React.FC = () => {
       </p>
       <button
         className="rounded-full bg-white/90 px-10 py-3 text-blue-default no-underline transition hover:bg-white hover:text-blue-darker"
-        onClick={sessionData ? () => void signOut() : () => void signIn()}
+        onClick={sessionData ? () => void handleSignOut() : () => void signIn()}
       >
         {sessionData ? "Sign out" : "Sign in"}
       </button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,7 +45,7 @@ const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
   const handleSignOut = async () => {
-    localStorage.polisUserXID = undefined;
+    localStorage.clear();
     await signOut();
   };
 


### PR DESCRIPTION
This is a bug that we observed when a user would log out of their browser session, log in with a different user name, but Pol.is would not reset for the new user. 

The ideal behavior is:
* User 1 takes the Pol.is survey
* User 1 logs out 
* User 2 logs in on the same browser
* User 2 is able to take the pol.is survey