### PR TITLE
Add county and region columns to export

### DIFF
--- a/src/pages/api/export.js
+++ b/src/pages/api/export.js
@@ -75,6 +75,26 @@ const handler = nc({
             },
           });
 
+          // Gets the row for the survey answer for the question "What is your workshop?"
+          // This is question 16 in the survey
+          const surveyAnswerPromise = prisma.userSurveyAnswers.findFirst({
+            where: {
+              userId: row.xid,
+              questionId: "16",
+            },
+          });
+          const surveyPromise = surveyAnswerPromise.then((answer) => {
+            if (answer !== null) {
+              let [county, location] = answer.answerValue.split("-");
+              row.county = county;
+              row.location = location;
+            } else {
+              row.county = "";
+              row.location = "";
+            }
+            return row;
+          });
+
           // add census tract and zipcode to the row if they are available
           const rowPromise = userPromise.then((user) => {
             var censusTract = "";
@@ -90,9 +110,12 @@ const handler = nc({
 
           // push the row into an array to resolve during end callback
           output.push(rowPromise);
+          output.push(surveyPromise);
         } else {
           row.censustract = "";
           row.zipcode = "";
+          row.county = "";
+          row.location = "";
           output.push(Promise.resolve(row));
         }
       })

--- a/src/pages/api/export.js
+++ b/src/pages/api/export.js
@@ -85,12 +85,12 @@ const handler = nc({
           });
           const surveyPromise = surveyAnswerPromise.then((answer) => {
             if (answer !== null) {
-              let [county, location] = answer.answerValue.split("-");
+              let [county, region] = answer.answerValue.split("-");
               row.county = county;
-              row.location = location;
+              row.region = region;
             } else {
               row.county = "";
-              row.location = "";
+              row.region = "";
             }
             return row;
           });
@@ -115,7 +115,7 @@ const handler = nc({
           row.censustract = "";
           row.zipcode = "";
           row.county = "";
-          row.location = "";
+          row.region = "";
           output.push(Promise.resolve(row));
         }
       })


### PR DESCRIPTION
Scott requested two additional export columns based on the user's answer for the workshop question in the demographic survey. The first column is county and the second is region. The value is stored in the database as a hyphenated value. This PR should add the two columns in the export and the values should be based on the user's answer. 

Prisma wouldn't let me use findUnique so I used findFirst. I don't think this should cause issues, but let me know if it does. If a user retakes the demographic survey, it should erase the original answers and replace them so each userId and question should have a unique value. 