### PR TITLE
Easy lint fixes

### DIFF
--- a/src/components/censusmap.tsx
+++ b/src/components/censusmap.tsx
@@ -12,8 +12,9 @@ import {
 import CensusTractData from "../data/census-tracts_min.json";
 import "leaflet/dist/leaflet.css";
 import type { GeoJsonObject, Feature, Geometry } from "geojson";
-import { Ref, useEffect, useRef, useState } from "react";
-import { Layer, LeafletMouseEvent } from "leaflet";
+import type { Ref } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { Layer, LeafletMouseEvent } from "leaflet";
 import EsriLeafletGeoSearch from "react-esri-leaflet/plugins/EsriLeafletGeoSearch";
 import { api } from "../utils/api";
 import Link from "next/link";

--- a/src/pages/api/export.js
+++ b/src/pages/api/export.js
@@ -31,7 +31,7 @@ function handleError(error, res) {
 }
 
 const handler = nc({
-  onError: (err, req, res, next) => handleError(err, res),
+  onError: (err, req, res) => handleError(err, res),
   onNoMatch: (req, res) => {
     res.status(404).end("Page is not found");
   },

--- a/src/pages/polissurvey.tsx
+++ b/src/pages/polissurvey.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { api } from "../utils/api";
 import Link from "next/link";
 import ProgressBar from "../components/ProgressBar";


### PR DESCRIPTION
Easy lint fixes

## Before

```
@MichaelTamaki ➜ /workspaces/HIERR (lint-fixes) $ npm run lint

> hierr@0.1.0 lint
> next lint

info  - Loaded env from /workspaces/HIERR/.env

./src/components/censusmap.tsx
15:1  Warning: Import "Ref" is only used as types.  @typescript-eslint/consistent-type-imports
16:1  Warning: All imports in the declaration are only used as types. Use `import type`.  @typescript-eslint/consistent-type-imports
64:6  Warning: React Hook useEffect has a missing dependency: 'censusTractDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
67:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
191:38  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./src/components/survey/demographicssurvey.tsx
71:6  Warning: React Hook useEffect has a missing dependency: 'surveyCompletedDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
127:5  Warning: React Hook useCallback has missing dependencies: 'postUserAnswer' and 'surveyData'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps

./src/components/survey/dropdownAnswers.tsx
41:6  Warning: React Hook useEffect has missing dependencies: 'getFilteredWorkshopsByCounty' and 'setDisabled'. Either include them or remove the dependency array. If 'setDisabled' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps

./src/components/zipcode.tsx
39:6  Warning: React Hook useEffect has a missing dependency: 'zipCodeDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
49:6  Warning: React Hook useCallback has missing dependencies: 'removeUserZipCode' and 'zipcode'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps

./src/pages/api/export.js
34:28  Warning: 'next' is defined but never used.  @typescript-eslint/no-unused-vars

./src/pages/polissurvey.tsx
3:21  Warning: 'useState' is defined but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
```

## After

```
@MichaelTamaki ➜ /workspaces/HIERR (lint-fixes) $ npm run lint

> hierr@0.1.0 lint
> next lint

info  - Loaded env from /workspaces/HIERR/.env

./src/components/censusmap.tsx
65:6  Warning: React Hook useEffect has a missing dependency: 'censusTractDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
68:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
192:38  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./src/components/survey/demographicssurvey.tsx
71:6  Warning: React Hook useEffect has a missing dependency: 'surveyCompletedDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
127:5  Warning: React Hook useCallback has missing dependencies: 'postUserAnswer' and 'surveyData'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps

./src/components/survey/dropdownAnswers.tsx
41:6  Warning: React Hook useEffect has missing dependencies: 'getFilteredWorkshopsByCounty' and 'setDisabled'. Either include them or remove the dependency array. If 'setDisabled' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps

./src/components/zipcode.tsx
39:6  Warning: React Hook useEffect has a missing dependency: 'zipCodeDB'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
49:6  Warning: React Hook useCallback has missing dependencies: 'removeUserZipCode' and 'zipcode'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
```